### PR TITLE
Fix grammar in library README

### DIFF
--- a/lib/README
+++ b/lib/README
@@ -2,7 +2,7 @@
 This directory is intended for project specific (private) libraries.
 PlatformIO will compile them to static libraries and link into executable file.
 
-The source code of each library should be placed in a an own separate directory
+The source code of each library should be placed in its own separate directory
 ("lib/your_library_name/[here are source files]").
 
 For example, see a structure of the following two libraries `Foo` and `Bar`:


### PR DESCRIPTION
## Summary
- fix a grammar mistake in `lib/README`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68647986f760832e8d862eed6adfdb22