### PR TITLE
Switch project to C++20

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [env]
 test_framework = googletest
-build_flags = -std=gnu++17
+build_flags = -std=gnu++20
 build_unflags = -std=gnu++11
 
 [env:native]


### PR DESCRIPTION
## Summary
- update `platformio.ini` to use `-std=gnu++20`

## Testing
- `pio test` *(fails: xtensa-esp32-elf-g++: error: unrecognized command line option '-std=gnu++20')*

------
https://chatgpt.com/codex/tasks/task_e_6864a6efcebc832e88a3c6c84f2b1d53