### PR TITLE
Improve accuracy of spinning calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ This project aims to provide a robust and flexible calibration mechanism for win
 
 ## Usage
 
-Upload the code to your Arduino board and follow the on-screen prompts to perform calibration.
-Upon startup the firmware guides you through a spinning calibration process.
-Simply align the vane to your forward reference and rotate it slowly.
-Each stable position is detected automatically and progress is printed to the
-serial console until a full rotation is captured.
+Upload the code to your Arduino board and open the serial monitor. After
+aligning the vane to your forward reference press any key to begin
+calibration. Rotate the vane slowly; readings are clustered into unique
+positions using an adaptive threshold with debouncing and anomaly
+detection. Progress is displayed as a certainty percentage that increases
+as more rotations confirm the map. Press `s` to stop once you are satisfied
+with the certainty.
 
 ---
 

--- a/lib/WindVane/Calibration/Strategies/SpinningMethod.cpp
+++ b/lib/WindVane/Calibration/Strategies/SpinningMethod.cpp
@@ -10,86 +10,215 @@
 #include <fstream>
 #include <iostream>
 #include <thread>
+#include <algorithm>
+#include <numeric>
 #endif
 
 using namespace std::chrono_literals;
 
+// ---------------------- Debouncer implementation ---------------------
+SpinningMethod::Debouncer::Debouncer(size_t size, int majority)
+    : _buffer(size, 0.0f), _index(0), _majority(majority), _filled(false) {}
+
+void SpinningMethod::Debouncer::addSample(float value) {
+  _buffer[_index] = value;
+  _index = (_index + 1) % _buffer.size();
+  if (_index == 0)
+    _filled = true;
+}
+
+bool SpinningMethod::Debouncer::full() const { return _filled; }
+
+float SpinningMethod::Debouncer::average() const {
+  float sum = std::accumulate(_buffer.begin(), _buffer.end(), 0.0f);
+  return sum / (_filled ? _buffer.size() : _index);
+}
+
+float SpinningMethod::Debouncer::noise() const {
+  size_t count = _filled ? _buffer.size() : _index;
+  if (count == 0)
+    return 0.0f;
+  float avg = average();
+  float sum = 0.0f;
+  for (size_t i = 0; i < count; ++i) {
+    float diff = _buffer[i] - avg;
+    sum += diff * diff;
+  }
+  return std::sqrt(sum / count);
+}
+
+bool SpinningMethod::Debouncer::stable(float tolerance) const {
+  size_t count = _filled ? _buffer.size() : _index;
+  if (count == 0)
+    return false;
+  float last = _buffer[((_index == 0 ? count : _index) - 1) % count];
+  int within = 0;
+  for (size_t i = 0; i < count; ++i) {
+    if (std::fabs(_buffer[i] - last) < tolerance)
+      ++within;
+  }
+  return within >= _majority;
+}
+
+// ---------------------- SpinningMethod ---------------------
+
 SpinningMethod::SpinningMethod(IADC *adc) : _adc(adc) {}
 
+float SpinningMethod::adaptiveThreshold() const {
+  if (_positions.size() < 2)
+    return 0.05f;
+
+  std::vector<float> values;
+  values.reserve(_positions.size());
+  for (const auto &p : _positions)
+    values.push_back(p.value);
+  std::sort(values.begin(), values.end());
+  float sum = 0.0f;
+  for (size_t i = 1; i < values.size(); ++i)
+    sum += values[i] - values[i - 1];
+  sum += 1.0f - values.back() + values.front();
+  float avgSep = sum / values.size();
+  float noise = _debouncer.noise();
+  return std::max(noise * 2.0f, avgSep * 0.5f);
+}
+
 bool SpinningMethod::isNewPosition(float reading, float threshold) const {
-  if (_positions.empty())
+  for (const auto &pos : _positions) {
+    if (std::fabs(reading - pos.value) < threshold)
+      return false;
+  }
+  return true;
+}
+
+bool SpinningMethod::isAnomaly(float reading, float last) const {
+  if (reading < 0.0f || reading > 1.0f)
     return true;
-  return std::fabs(reading - _positions.back()) > threshold;
+  if (std::fabs(reading - last) > 0.2f)
+    return true;
+  return false;
+}
+
+void SpinningMethod::addOrUpdatePosition(float reading, float threshold) {
+  for (auto &pos : _positions) {
+    if (std::fabs(reading - pos.value) < threshold) {
+      ++pos.count;
+      pos.value += (reading - pos.value) / pos.count;
+      pos.min = std::min(pos.min, reading);
+      pos.max = std::max(pos.max, reading);
+      return;
+    }
+  }
+  _positions.push_back({reading, reading, reading, 1});
 }
 
 void SpinningMethod::saveCalibration() const {
 #ifdef ARDUINO
-  EEPROM.begin(_positions.size() * sizeof(float));
+  EEPROM.begin(_positions.size() * sizeof(Position));
   for (size_t i = 0; i < _positions.size(); ++i) {
-    EEPROM.put(i * sizeof(float), _positions[i]);
+    EEPROM.put(i * sizeof(Position), _positions[i]);
   }
   EEPROM.commit();
 #else
   std::ofstream ofs("calibration.dat");
-  for (size_t i = 0; i < _positions.size(); ++i) {
-    ofs << _positions[i] << "\n";
+  for (const auto &p : _positions) {
+    ofs << p.value << ',' << p.min << ',' << p.max << ',' << p.count << "\n";
   }
 #endif
 }
 
 void SpinningMethod::calibrate() {
 #ifdef ARDUINO
-  Serial.println(F("Align the vane to forward reference then spin."));
+  Serial.println(
+      F("Align vane to forward reference and press any key to start."));
+  while (!Serial.available()) {
+    delay(10);
+  }
+  while (Serial.available())
+    Serial.read();
 #else
-  std::cout << "Align the vane to forward reference then spin." << std::endl;
+  std::cout << "Align vane to forward reference and press ENTER to start."
+            << std::endl;
+  std::cin.get();
 #endif
 
-  const float threshold = 0.05f;           // sensor difference threshold
-  const int stableSamples = 5;             // debounce count
   const std::chrono::milliseconds sampleDelay(10);
 
   float last = _adc->read();
-  int stableCount = 0;
   _positions.clear();
+  _debouncer = Debouncer();
+  _debouncer.addSample(last);
 
-  while (true) {
+  size_t lastPositionCount = 0;
+  int rotationsWithoutNew = 0;
+  bool stop = false;
+
+  while (!stop) {
     float reading = _adc->read();
-    if (std::fabs(reading - last) < threshold) {
-      ++stableCount;
-    } else {
-      stableCount = 0;
+
+    if (isAnomaly(reading, last)) {
+      ++_anomalyCount;
+      continue;
+    }
+
+    _debouncer.addSample(reading);
+    float threshold = adaptiveThreshold();
+
+    if (_debouncer.stable(threshold)) {
+      bool newPos = isNewPosition(reading, threshold);
+      addOrUpdatePosition(reading, threshold);
+      if (newPos) {
+        rotationsWithoutNew = 0;
+        lastPositionCount = _positions.size();
+#ifdef ARDUINO
+        Serial.print(F("Position detected: "));
+        Serial.println(_positions.size());
+#else
+        std::cout << "Position detected: " << _positions.size() << std::endl;
+#endif
+      } else if (!_positions.empty() &&
+                 std::fabs(reading - _positions.front().value) < threshold) {
+        if (lastPositionCount == _positions.size()) {
+          ++rotationsWithoutNew;
+        } else {
+          rotationsWithoutNew = 0;
+          lastPositionCount = _positions.size();
+        }
+      }
       last = reading;
     }
 
-    if (stableCount >= stableSamples && isNewPosition(reading, threshold)) {
-      _positions.push_back(reading);
+    float certainty = std::min(rotationsWithoutNew / 2.0f, 1.0f) * 100.0f;
 #ifdef ARDUINO
-      Serial.print(F("Position detected: "));
-      Serial.println(_positions.size());
-#else
-      std::cout << "Position detected: " << _positions.size() << std::endl;
-#endif
-
-      // consider calibration complete after returning to first position
-      if (_positions.size() > 1 &&
-          std::fabs(reading - _positions.front()) < threshold) {
-        break;
-      }
+    Serial.print(F("Certainty: "));
+    Serial.print(certainty, 1);
+    Serial.println(F("%"));
+    if (Serial.available()) {
+      char c = Serial.read();
+      if (c == 's' || c == 'S')
+        stop = true;
     }
-
-#ifdef ARDUINO
     delay(sampleDelay.count());
 #else
+    std::cout << "Certainty: " << certainty << "%" << std::endl;
+    if (std::cin.rdbuf()->in_avail()) {
+      char c;
+      std::cin.get(c);
+      if (c == 's' || c == 'S')
+        stop = true;
+    }
     std::this_thread::sleep_for(sampleDelay);
 #endif
+
+    if (rotationsWithoutNew >= 3)
+      stop = true;
+    last = reading;
   }
 
 #ifdef ARDUINO
-  Serial.println(F("Calibration complete."));
+  Serial.println(F("Calibration stopped."));
 #else
-  std::cout << "Calibration complete." << std::endl;
+  std::cout << "Calibration stopped." << std::endl;
 #endif
 
   saveCalibration();
 }
-

--- a/lib/WindVane/Calibration/Strategies/SpinningMethod.h
+++ b/lib/WindVane/Calibration/Strategies/SpinningMethod.h
@@ -2,6 +2,8 @@
 #include "ICalibrationStrategy.h"
 #include <vector>
 #include <cstdint>
+#include <array>
+#include <optional>
 
 class IADC;
 
@@ -15,9 +17,38 @@ public:
   void calibrate() override;
 
 private:
+  struct Position {
+    float value;
+    float min;
+    float max;
+    int count;
+  };
+
+  class Debouncer {
+  public:
+    Debouncer(size_t size = 5, int majority = 3);
+    void addSample(float value);
+    bool stable(float tolerance) const;
+    float average() const;
+    float noise() const;
+    bool full() const;
+
+  private:
+    std::vector<float> _buffer;
+    size_t _index{0};
+    int _majority{3};
+    bool _filled{false};
+  };
+
   IADC *_adc;
-  std::vector<float> _positions;
+  std::vector<Position> _positions;
+  Debouncer _debouncer;
+  int _anomalyCount{0};
+  size_t _rotationsWithoutNew{0};
 
   bool isNewPosition(float reading, float threshold) const;
+  void addOrUpdatePosition(float reading, float threshold);
+  float adaptiveThreshold() const;
+  bool isAnomaly(float reading, float last) const;
   void saveCalibration() const;
 };


### PR DESCRIPTION
## Summary
- refine usage instructions in README
- extend Position struct with min/max tracking
- add Debouncer helper for stability checking
- implement adaptive threshold, anomaly detection and automatic stop
- save extended calibration data

## Testing
- `g++ -std=c++20 -Ilib/WindVane -Ilib -Isrc -c lib/WindVane/Calibration/Strategies/SpinningMethod.cpp`


------
https://chatgpt.com/codex/tasks/task_e_6864dd16f6b8832e98e9147ca8a30000