### PR TITLE
Implement robust clustering calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ This project aims to provide a robust and flexible calibration mechanism for win
 
 Upload the code to your Arduino board and open the serial monitor. After
 aligning the vane to your forward reference press any key to begin
-calibration. Slowly rotate the vane; each stable position is detected and
-reported along with a certainty percentage that increases as additional
-rotations reveal no new positions. When you are happy with the certainty press
-`s` to stop the calibration and store the data.
+calibration. Slowly rotate the vane; the calibrator dynamically clusters
+stable readings to determine each switch position. Progress is reported as
+"position detected" messages. When all positions are found or you are happy
+with the results press `s` to stop and store the calibration. Diagnostics are
+printed at the end showing mean, min and max for each detected position.
 
 ---
 

--- a/lib/WindVane/Calibration/Strategies/SpinningMethod.h
+++ b/lib/WindVane/Calibration/Strategies/SpinningMethod.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "ICalibrationStrategy.h"
+#include <deque>
 #include <vector>
 #include <cstdint>
 
@@ -15,9 +16,19 @@ public:
   void calibrate() override;
 
 private:
-  IADC *_adc;
-  std::vector<float> _positions;
+  struct PositionCluster {
+    float mean;
+    float min;
+    float max;
+    int count;
+  };
 
-  bool isNewPosition(float reading, float threshold) const;
+  IADC *_adc;
+  std::vector<PositionCluster> _clusters;
+  std::deque<float> _recent;
+  int _anomalyCount{0};
+
+  bool addOrUpdateCluster(float reading, float threshold);
   void saveCalibration() const;
+  void printDiagnostics() const;
 };


### PR DESCRIPTION
## Summary
- add `PositionCluster` storage to spinning method
- implement majority buffer debounce and cluster updates
- print diagnostics after calibration
- document usage updates for dynamic clustering

## Testing
- `platformio test -e native` *(fails: undefined reference to `typeinfo for ESP32ADC`)*

------
https://chatgpt.com/codex/tasks/task_e_6864e35b1e44832e945b8c9a8880c029