### PR TITLE
Refactor WindVane calibration ownership

### DIFF
--- a/lib/WindVane/Calibration/CalibrationManager.cpp
+++ b/lib/WindVane/Calibration/CalibrationManager.cpp
@@ -1,9 +1,10 @@
 #include "Calibration/CalibrationManager.h"
 #include <iostream>
 
-CalibrationManager::CalibrationManager(ICalibrationStrategy *strategy,
+CalibrationManager::CalibrationManager(std::unique_ptr<ICalibrationStrategy> strategy,
                                        IIOHandler *io, IDiagnostics *diag)
-    : calibrationStrategy(strategy), status(CalibrationStatus::NotStarted),
+    : calibrationStrategy(std::move(strategy)),
+      status(CalibrationStatus::NotStarted),
       _io(io), _diag(diag) {}
 
 bool CalibrationManager::startCalibration() {

--- a/lib/WindVane/Calibration/CalibrationManager.h
+++ b/lib/WindVane/Calibration/CalibrationManager.h
@@ -2,6 +2,7 @@
 #include "Calibration/Strategies/ICalibrationStrategy.h"
 #include "../IO/IIOHandler.h"
 #include "../Diagnostics/IDiagnostics.h"
+#include <memory>
 
 class CalibrationManager {
 public:
@@ -12,8 +13,8 @@ public:
     Completed
   };
 
-  CalibrationManager(ICalibrationStrategy *strategy, IIOHandler *io,
-                     IDiagnostics *diag);
+  CalibrationManager(std::unique_ptr<ICalibrationStrategy> strategy,
+                     IIOHandler *io, IDiagnostics *diag);
 
   // Starts the calibration process and sets status to AwaitingStart
   bool startCalibration();
@@ -34,7 +35,7 @@ public:
   CalibrationStatus getStatus() const;
 
 private:
-  ICalibrationStrategy *calibrationStrategy;
+  std::unique_ptr<ICalibrationStrategy> calibrationStrategy;
   CalibrationStatus status;
   IIOHandler *_io;
   IDiagnostics *_diag;

--- a/lib/WindVane/Calibration/StrategyFactory.cpp
+++ b/lib/WindVane/Calibration/StrategyFactory.cpp
@@ -1,0 +1,15 @@
+#include "StrategyFactory.h"
+#include "Strategies/SpinningMethod.h"
+
+std::unique_ptr<ICalibrationStrategy> createCalibrationStrategy(
+    CalibrationMethod method,
+    IADC *adc,
+    ICalibrationStorage *storage,
+    IIOHandler *io,
+    IDiagnostics *diag) {
+    switch (method) {
+    case CalibrationMethod::SPINNING:
+    default:
+        return std::make_unique<SpinningMethod>(adc, storage, io, diag);
+    }
+}

--- a/lib/WindVane/Calibration/StrategyFactory.h
+++ b/lib/WindVane/Calibration/StrategyFactory.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "Calibrator.h"
+#include "Strategies/ICalibrationStrategy.h"
+#include "../IADC.h"
+#include "../Storage/ICalibrationStorage.h"
+#include "../IO/IIOHandler.h"
+#include "../Diagnostics/IDiagnostics.h"
+#include <memory>
+
+std::unique_ptr<ICalibrationStrategy> createCalibrationStrategy(
+    CalibrationMethod method,
+    IADC *adc,
+    ICalibrationStorage *storage,
+    IIOHandler *io,
+    IDiagnostics *diag);

--- a/lib/WindVane/WindVane.cpp
+++ b/lib/WindVane/WindVane.cpp
@@ -1,5 +1,5 @@
 #include "WindVane.h"
-#include "Calibration/Strategies/SpinningMethod.h"
+#include "Calibration/StrategyFactory.h"
 #include "Storage/ICalibrationStorage.h"
 #include "IO/IIOHandler.h"
 #include "Diagnostics/IDiagnostics.h"
@@ -9,8 +9,8 @@ WindVane::WindVane(IADC *adc, WindVaneType type,
                    ICalibrationStorage *storage, IIOHandler *io,
                    IDiagnostics *diag)
     : _adc(adc), _type(type), _storage(storage) {
-    _calibrationManager = new CalibrationManager(
-        new SpinningMethod(adc, storage, io, diag), io, diag);
+    auto strategy = createCalibrationStrategy(method, adc, storage, io, diag);
+    _calibrationManager = std::make_unique<CalibrationManager>(std::move(strategy), io, diag);
 }
 
 void WindVane::startCalibration() {

--- a/lib/WindVane/WindVane.h
+++ b/lib/WindVane/WindVane.h
@@ -3,9 +3,11 @@
 #include "Calibration/Calibrator.h"
 #include "IADC.h"
 #include "Calibration/CalibrationManager.h"
+#include "Calibration/StrategyFactory.h"
 #include "Storage/ICalibrationStorage.h"
 #include "IO/IIOHandler.h"
 #include "Diagnostics/IDiagnostics.h"
+#include <memory>
 
 /**
  * @enum WindVaneType
@@ -75,6 +77,6 @@ private:
   IADC *_adc;
   Calibrator *_calibrator;
   WindVaneType _type;
-  CalibrationManager *_calibrationManager;
+  std::unique_ptr<CalibrationManager> _calibrationManager;
   ICalibrationStorage *_storage;
 };


### PR DESCRIPTION
## Summary
- avoid leaks by using `std::unique_ptr` for `CalibrationManager`
- create a `StrategyFactory` for extensible calibration strategies
- construct `CalibrationManager` using the strategy factory

## Testing
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_68652afecbe4832eb54b38561663ecda