### PR TITLE
Add interactive Arduino menu and EEPROM loading

### DIFF
--- a/lib/Menu/ArduinoMenu.cpp
+++ b/lib/Menu/ArduinoMenu.cpp
@@ -1,0 +1,135 @@
+#include "ArduinoMenu.h"
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#endif
+
+ArduinoMenu::ArduinoMenu(WindVane* vane, IIOHandler* io, IDiagnostics* diag)
+    : _vane(vane), _io(io), _diag(diag), _state(State::Main),
+      _lastActivity(0), _lastCalibration(0) {}
+
+void ArduinoMenu::begin() {
+    showMainMenu();
+    _lastActivity = millis();
+}
+
+void ArduinoMenu::update() {
+    if (_io->hasInput()) {
+        char c = _io->readInput();
+        _lastActivity = millis();
+        switch (_state) {
+            case State::Main: handleMainInput(c); break;
+            case State::LiveDisplay: if (c=='q'||c=='Q') { _state=State::Main; showMainMenu(); } break;
+            default: break;
+        }
+    }
+
+    switch (_state) {
+        case State::LiveDisplay: updateLiveDisplay(); break;
+        default: break;
+    }
+
+    if (millis() - _lastActivity > 30000 && _state != State::Main) {
+        _state = State::Main;
+        showMainMenu();
+    }
+
+    showStatusLine();
+}
+
+void ArduinoMenu::showStatusLine() {
+    float dir = _vane->direction();
+    unsigned long ago = (millis() - _lastCalibration)/60000UL;
+#ifdef ARDUINO
+    Serial.print("\rDir: ");
+    Serial.print(dir,1);
+    Serial.print("\xC2\xB0 Status: OK Cal: ");
+    Serial.print(ago);
+    Serial.print("m    \r");
+#endif
+}
+
+void ArduinoMenu::showMainMenu() {
+#ifdef ARDUINO
+    Serial.println();
+    Serial.println("=== Wind Vane Menu ===");
+    Serial.println("[D] Display direction");
+    Serial.println("[C] Calibrate" );
+    Serial.println("[G] Diagnostics" );
+    Serial.println("[S] Settings" );
+    Serial.println("[H] Help" );
+    Serial.println("Choose option: " );
+#endif
+}
+
+void ArduinoMenu::handleMainInput(char c) {
+    switch(c) {
+        case 'D': case 'd':
+            _state = State::LiveDisplay;
+            Serial.println("Live direction - press Q to quit");
+            break;
+        case 'C': case 'c':
+            _state = State::Calibrate;
+            runCalibration();
+            _state = State::Main;
+            showMainMenu();
+            break;
+        case 'G': case 'g':
+            _state = State::Diagnostics;
+            showDiagnostics();
+            _state = State::Main;
+            showMainMenu();
+            break;
+        case 'S': case 's':
+            _state = State::Settings;
+            settingsMenu();
+            _state = State::Main;
+            showMainMenu();
+            break;
+        case 'H': case 'h':
+            _state = State::Help;
+            showHelp();
+            _state = State::Main;
+            showMainMenu();
+            break;
+        default:
+            break;
+    }
+}
+
+void ArduinoMenu::updateLiveDisplay() {
+    static unsigned long last = 0;
+    if (millis() - last > 1000) {
+        last = millis();
+#ifdef ARDUINO
+        Serial.print("\rDir: ");
+        Serial.print(_vane->direction(),1);
+        Serial.print("\xC2\xB0   \r");
+#endif
+    }
+}
+
+void ArduinoMenu::runCalibration() {
+    if (_io->yesNoPrompt("Start calibration? (Y/N)")) {
+        _vane->runCalibration();
+        _lastCalibration = millis();
+    }
+}
+
+void ArduinoMenu::showDiagnostics() {
+#ifdef ARDUINO
+    Serial.println("Diagnostics not implemented");
+#endif
+}
+
+void ArduinoMenu::settingsMenu() {
+#ifdef ARDUINO
+    Serial.println("Settings not implemented");
+#endif
+}
+
+void ArduinoMenu::showHelp() {
+#ifdef ARDUINO
+    Serial.println("Use menu keys to operate.\nC: Calibrate, D: Display direction");
+#endif
+}

--- a/lib/Menu/ArduinoMenu.h
+++ b/lib/Menu/ArduinoMenu.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <WindVane.h>
+#include <IO/IIOHandler.h>
+#include <Diagnostics/IDiagnostics.h>
+
+class ArduinoMenu {
+public:
+    ArduinoMenu(WindVane* vane, IIOHandler* io, IDiagnostics* diag);
+    void begin();
+    void update();
+private:
+    enum class State { Main, LiveDisplay, Calibrate, Diagnostics, Settings, Help };
+
+    WindVane* _vane;
+    IIOHandler* _io;
+    IDiagnostics* _diag;
+    State _state;
+    unsigned long _lastActivity;
+    unsigned long _lastCalibration;
+
+    void showMainMenu();
+    void showStatusLine();
+    void handleMainInput(char c);
+    void updateLiveDisplay();
+    void runCalibration();
+    void showDiagnostics();
+    void settingsMenu();
+    void showHelp();
+};

--- a/lib/Menu/ArduinoMenu.h
+++ b/lib/Menu/ArduinoMenu.h
@@ -2,6 +2,7 @@
 #include <WindVane.h>
 #include <IO/IIOHandler.h>
 #include <Diagnostics/IDiagnostics.h>
+#include <Diagnostics/BufferedDiagnostics.h>
 
 class ArduinoMenu {
 public:
@@ -14,6 +15,7 @@ private:
     WindVane* _vane;
     IIOHandler* _io;
     IDiagnostics* _diag;
+    BufferedDiagnostics* _buffered{nullptr};
     State _state;
     unsigned long _lastActivity;
     unsigned long _lastCalibration;

--- a/lib/WindVane/Calibration/CalibrationManager.cpp
+++ b/lib/WindVane/Calibration/CalibrationManager.cpp
@@ -39,8 +39,9 @@ float CalibrationManager::getCalibratedData(float rawWindDirection) const {
 }
 
 void CalibrationManager::editCalibrationData(/*data*/) {
-  // Logic to edit calibration data
-  // This could call methods on the calibrationStrategy to update its internal data
+  if (_io && _io->yesNoPrompt("Recalibrate now? (Y/N)")) {
+    beginCalibration();
+  }
 }
 
 CalibrationManager::CalibrationStatus CalibrationManager::getStatus() const {

--- a/lib/WindVane/Diagnostics/BufferedDiagnostics.h
+++ b/lib/WindVane/Diagnostics/BufferedDiagnostics.h
@@ -1,0 +1,39 @@
+#pragma once
+#include "IDiagnostics.h"
+#include <deque>
+#include <string>
+#ifdef ARDUINO
+#include <Arduino.h>
+#endif
+
+class BufferedDiagnostics : public IDiagnostics {
+public:
+    explicit BufferedDiagnostics(size_t maxEntries = 10)
+        : _max(maxEntries) {}
+
+    void info(const char* msg) override {
+#ifdef ARDUINO
+        Serial.println(msg);
+#endif
+        push("INFO: " + std::string(msg));
+    }
+
+    void warn(const char* msg) override {
+#ifdef ARDUINO
+        Serial.println(msg);
+#endif
+        push("WARN: " + std::string(msg));
+    }
+
+    const std::deque<std::string>& history() const { return _messages; }
+
+private:
+    size_t _max;
+    std::deque<std::string> _messages;
+
+    void push(const std::string& m) {
+        if (_messages.size() >= _max)
+            _messages.pop_front();
+        _messages.push_back(m);
+    }
+};

--- a/lib/WindVane/Storage/EEPROMCalibrationStorage.cpp
+++ b/lib/WindVane/Storage/EEPROMCalibrationStorage.cpp
@@ -12,6 +12,7 @@ void EEPROMCalibrationStorage::save(const std::vector<ClusterData>& clusters, in
     EEPROM.begin(512);
     EEPROM.put(addr, version); addr += sizeof(int);
     uint32_t timestamp = millis();
+    _lastTimestamp = timestamp;
     EEPROM.put(addr, timestamp); addr += sizeof(uint32_t);
     uint16_t count = static_cast<uint16_t>(clusters.size());
     EEPROM.put(addr, count); addr += sizeof(uint16_t);
@@ -30,8 +31,9 @@ bool EEPROMCalibrationStorage::load(std::vector<ClusterData>& clusters, int &ver
     size_t addr = _startAddress;
     EEPROM.begin(512);
     EEPROM.get(addr, version); addr += sizeof(int);
-    uint32_t timestamp = 0; // unused currently
+    uint32_t timestamp = 0;
     EEPROM.get(addr, timestamp); addr += sizeof(uint32_t);
+    _lastTimestamp = timestamp;
     uint16_t count = 0;
     EEPROM.get(addr, count); addr += sizeof(uint16_t);
     if (count == 0 || count > 64) {

--- a/lib/WindVane/Storage/EEPROMCalibrationStorage.cpp
+++ b/lib/WindVane/Storage/EEPROMCalibrationStorage.cpp
@@ -9,10 +9,14 @@ EEPROMCalibrationStorage::EEPROMCalibrationStorage(size_t startAddress)
 void EEPROMCalibrationStorage::save(const std::vector<ClusterData>& clusters, int version) {
 #ifdef ARDUINO
     size_t addr = _startAddress;
-    EEPROM.begin(clusters.size() * sizeof(float));
+    EEPROM.begin(512);
+    EEPROM.put(addr, version); addr += sizeof(int);
+    uint32_t timestamp = millis();
+    EEPROM.put(addr, timestamp); addr += sizeof(uint32_t);
+    uint16_t count = static_cast<uint16_t>(clusters.size());
+    EEPROM.put(addr, count); addr += sizeof(uint16_t);
     for (const auto& c : clusters) {
-        EEPROM.put(addr, c.mean);
-        addr += sizeof(float);
+        EEPROM.put(addr, c); addr += sizeof(ClusterData);
     }
     EEPROM.commit();
 #else
@@ -23,13 +27,25 @@ void EEPROMCalibrationStorage::save(const std::vector<ClusterData>& clusters, in
 
 bool EEPROMCalibrationStorage::load(std::vector<ClusterData>& clusters, int &version) {
 #ifdef ARDUINO
-    (void)version;
-    clusters.clear();
     size_t addr = _startAddress;
     EEPROM.begin(512);
-    // Implementation omitted for brevity
+    EEPROM.get(addr, version); addr += sizeof(int);
+    uint32_t timestamp = 0; // unused currently
+    EEPROM.get(addr, timestamp); addr += sizeof(uint32_t);
+    uint16_t count = 0;
+    EEPROM.get(addr, count); addr += sizeof(uint16_t);
+    if (count == 0 || count > 64) {
+        EEPROM.end();
+        return false;
+    }
+    clusters.clear();
+    for (uint16_t i = 0; i < count; ++i) {
+        ClusterData c{};
+        EEPROM.get(addr, c); addr += sizeof(ClusterData);
+        clusters.push_back(c);
+    }
     EEPROM.end();
-    return false;
+    return true;
 #else
     (void)clusters;
     (void)version;

--- a/lib/WindVane/Storage/EEPROMCalibrationStorage.h
+++ b/lib/WindVane/Storage/EEPROMCalibrationStorage.h
@@ -9,7 +9,9 @@ public:
     EEPROMCalibrationStorage(size_t startAddress = 0);
     void save(const std::vector<ClusterData>& clusters, int version) override;
     bool load(std::vector<ClusterData>& clusters, int &version) override;
+    uint32_t lastTimestamp() const { return _lastTimestamp; }
 
 private:
     size_t _startAddress;
+    uint32_t _lastTimestamp{0};
 };

--- a/lib/WindVane/Storage/FileCalibrationStorage.cpp
+++ b/lib/WindVane/Storage/FileCalibrationStorage.cpp
@@ -13,7 +13,8 @@ void FileCalibrationStorage::save(const std::vector<ClusterData>& clusters, int 
         fs::rename(_path, _path + ".bak");
     }
     std::ofstream ofs(_path);
-    ofs << version << " " << std::time(nullptr) << "\n";
+    _lastTimestamp = static_cast<uint32_t>(std::time(nullptr));
+    ofs << version << " " << _lastTimestamp << "\n";
     for (const auto& c : clusters) {
         ofs << c.mean << " " << c.min << " " << c.max << " " << c.count << "\n";
     }
@@ -27,6 +28,7 @@ bool FileCalibrationStorage::load(std::vector<ClusterData>& clusters, int &versi
     std::time_t ts;
     if (!(ifs >> version >> ts))
         return false;
+    _lastTimestamp = static_cast<uint32_t>(ts);
     ClusterData c{};
     while (ifs >> c.mean >> c.min >> c.max >> c.count) {
         clusters.push_back(c);

--- a/lib/WindVane/Storage/FileCalibrationStorage.h
+++ b/lib/WindVane/Storage/FileCalibrationStorage.h
@@ -8,7 +8,9 @@ public:
     explicit FileCalibrationStorage(const std::string& path);
     void save(const std::vector<ClusterData>& clusters, int version) override;
     bool load(std::vector<ClusterData>& clusters, int &version) override;
+    uint32_t lastTimestamp() const override { return _lastTimestamp; }
 
 private:
     std::string _path;
+    uint32_t _lastTimestamp{0};
 };

--- a/lib/WindVane/Storage/ICalibrationStorage.h
+++ b/lib/WindVane/Storage/ICalibrationStorage.h
@@ -7,4 +7,5 @@ public:
     virtual ~ICalibrationStorage() = default;
     virtual void save(const std::vector<ClusterData>& clusters, int version) = 0;
     virtual bool load(std::vector<ClusterData>& clusters, int &version) = 0;
+    virtual uint32_t lastTimestamp() const { return 0; }
 };

--- a/lib/WindVane/WindVane.cpp
+++ b/lib/WindVane/WindVane.cpp
@@ -28,3 +28,12 @@ void WindVane::runCalibration() {
     if (_calibrationManager)
         _calibrationManager->runCalibration();
 }
+
+CalibrationManager::CalibrationStatus WindVane::calibrationStatus() const {
+    return _calibrationManager ? _calibrationManager->getStatus()
+                               : CalibrationManager::CalibrationStatus::NotStarted;
+}
+
+uint32_t WindVane::lastCalibrationTimestamp() const {
+    return _storage ? _storage->lastTimestamp() : 0;
+}

--- a/lib/WindVane/WindVane.h
+++ b/lib/WindVane/WindVane.h
@@ -64,6 +64,12 @@ public:
    */
   void runCalibration();
 
+  /// Returns the calibration timestamp stored in the storage
+  uint32_t lastCalibrationTimestamp() const;
+
+  /// Returns the current calibration status
+  CalibrationManager::CalibrationStatus calibrationStatus() const;
+
 private:
   /**
    * @brief Gets the raw wind direction from the ADC interface.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include <Hardware/ESP32/ADC.h>
 #include <Storage/EEPROMCalibrationStorage.h>
 #include <IO/SerialIOHandler.h>
-#include <Diagnostics/SerialDiagnostics.h>
+#include <Diagnostics/BufferedDiagnostics.h>
 #include <Menu/ArduinoMenu.h>
 #include "Config.h"
 
@@ -12,7 +12,7 @@
 std::unique_ptr<ESP32ADC> adc;
 std::unique_ptr<EEPROMCalibrationStorage> storage;
 std::unique_ptr<SerialIOHandler> io;
-std::unique_ptr<SerialDiagnostics> diag;
+std::unique_ptr<BufferedDiagnostics> diag;
 std::unique_ptr<WindVane> windVane;
 std::unique_ptr<ArduinoMenu> menu;
 
@@ -21,7 +21,7 @@ void setup() {
   adc = std::make_unique<ESP32ADC>(WINDVANE_GPIO_PIN);
   storage = std::make_unique<EEPROMCalibrationStorage>(0);
   io = std::make_unique<SerialIOHandler>();
-  diag = std::make_unique<SerialDiagnostics>();
+  diag = std::make_unique<BufferedDiagnostics>();
   windVane = std::make_unique<WindVane>(adc.get(), WindVaneType::REED_SWITCH,
                                         CalibrationMethod::SPINNING,
                                         storage.get(), io.get(), diag.get());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,21 +1,35 @@
 #include <Arduino.h>
 #include <WindVane.h>
 #include <Hardware/ESP32/ADC.h>
-#include <Storage/FileCalibrationStorage.h>
+#include <Storage/EEPROMCalibrationStorage.h>
 #include <IO/SerialIOHandler.h>
 #include <Diagnostics/SerialDiagnostics.h>
+#include <Menu/ArduinoMenu.h>
 #include "Config.h"
 
-ESP32ADC adc(WINDVANE_GPIO_PIN);
-FileCalibrationStorage storage("calibration.dat");
-SerialIOHandler io;
-SerialDiagnostics diag;
-WindVane windVane(&adc, WindVaneType::REED_SWITCH, CalibrationMethod::SPINNING,
-                  &storage, &io, &diag);
+#include <memory>
+
+std::unique_ptr<ESP32ADC> adc;
+std::unique_ptr<EEPROMCalibrationStorage> storage;
+std::unique_ptr<SerialIOHandler> io;
+std::unique_ptr<SerialDiagnostics> diag;
+std::unique_ptr<WindVane> windVane;
+std::unique_ptr<ArduinoMenu> menu;
 
 void setup() {
   Serial.begin(115200);
-  windVane.runCalibration();
+  adc = std::make_unique<ESP32ADC>(WINDVANE_GPIO_PIN);
+  storage = std::make_unique<EEPROMCalibrationStorage>(0);
+  io = std::make_unique<SerialIOHandler>();
+  diag = std::make_unique<SerialDiagnostics>();
+  windVane = std::make_unique<WindVane>(adc.get(), WindVaneType::REED_SWITCH,
+                                        CalibrationMethod::SPINNING,
+                                        storage.get(), io.get(), diag.get());
+  menu = std::make_unique<ArduinoMenu>(windVane.get(), io.get(), diag.get());
+  menu->begin();
 }
 
-void loop() {}
+void loop() {
+  if (menu)
+    menu->update();
+}


### PR DESCRIPTION
## Summary
- add `ArduinoMenu` with basic menu system
- implement EEPROM calibration load/save
- allow editing calibration via `CalibrationManager`
- refactor `main.cpp` to dynamically instantiate objects and run menu

## Testing
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_686533c703e8832eb058f912f6299d9e