### PR TITLE
Add interactive settings and diagnostics

### DIFF
--- a/lib/Menu/ArduinoMenu.cpp
+++ b/lib/Menu/ArduinoMenu.cpp
@@ -5,6 +5,7 @@
 #else
 #include <chrono>
 #include <iostream>
+#include <limits>
 using std::cout; using std::endl;
 static unsigned long millis() {
     using namespace std::chrono;
@@ -13,9 +14,19 @@ static unsigned long millis() {
 }
 #endif
 
-ArduinoMenu::ArduinoMenu(WindVane* vane, IIOHandler* io, IDiagnostics* diag)
-    : _vane(vane), _io(io), _diag(diag), _state(State::Main),
-      _lastActivity(0), _lastCalibration(0) {
+static const char* compassPoint(float deg) {
+    static const char* pts[] = {"N","NE","E","SE","S","SW","W","NW"};
+    int idx = static_cast<int>((deg + 22.5f)/45.0f) & 7;
+    return pts[idx];
+}
+
+ArduinoMenu::ArduinoMenu(WindVane* vane, IIOHandler* io, IDiagnostics* diag,
+                         ICalibrationStorage* storage,
+                         ISettingsStorage* settingsStorage,
+                         SettingsData* settings)
+    : _vane(vane), _io(io), _diag(diag), _storage(storage),
+      _settingsStorage(settingsStorage), _settings(settings),
+      _state(State::Main), _lastActivity(0), _lastCalibration(0) {
     _buffered = dynamic_cast<BufferedDiagnostics*>(diag);
 }
 
@@ -31,7 +42,7 @@ void ArduinoMenu::update() {
         _lastActivity = millis();
         switch (_state) {
             case State::Main: handleMainInput(c); break;
-            case State::LiveDisplay: if (c=='q'||c=='Q') { _state=State::Main; showMainMenu(); } break;
+            case State::LiveDisplay: _state=State::Main; showMainMenu(); break;
             default: break;
         }
     }
@@ -62,14 +73,25 @@ void ArduinoMenu::showStatusLine() {
 #ifdef ARDUINO
     Serial.print("\rDir: ");
     Serial.print(dir,1);
-    Serial.print("\xC2\xB0 Status: ");
+    Serial.print("\xC2\xB0 (");
+    Serial.print(compassPoint(dir));
+    Serial.print(") Status: ");
     Serial.print(statusStr);
     Serial.print(" Cal: ");
     Serial.print(ago);
+    if (!_statusMsg.empty() && millis() < _msgExpiry) {
+        Serial.print(" ");
+        Serial.print(_statusMsg.c_str());
+    }
     Serial.print("m    \r");
+    if (!_statusMsg.empty() && millis() >= _msgExpiry) _statusMsg.clear();
 #else
-    cout << "\rDir: " << dir << "\xC2\xB0 Status: " << statusStr
-         << " Cal: " << ago << "m    \r" << std::flush;
+    cout << "\rDir: " << dir << "\xC2\xB0 (" << compassPoint(dir) << ") Status: " << statusStr
+         << " Cal: " << ago;
+    if (!_statusMsg.empty() && millis() < _msgExpiry)
+        cout << " " << _statusMsg.c_str();
+    cout << "m    \r" << std::flush;
+    if (!_statusMsg.empty() && millis() >= _msgExpiry) _statusMsg.clear();
 #endif
 }
 
@@ -94,13 +116,16 @@ void ArduinoMenu::showMainMenu() {
 }
 
 void ArduinoMenu::handleMainInput(char c) {
+    if (c == '\n' || c == '\r') { showMainMenu(); return; }
     switch(c) {
         case 'D': case 'd':
             _state = State::LiveDisplay;
+            if (_vane->calibrationStatus() != CalibrationManager::CalibrationStatus::Completed)
+                setStatusMessage("Warning: uncalibrated");
 #ifdef ARDUINO
-            Serial.println("Live direction - press Q to quit");
+            Serial.println("Live direction - press any key to return");
 #else
-            cout << "Live direction - press Q to quit" << endl;
+            cout << "Live direction - press any key to return" << endl;
 #endif
             break;
         case 'C': case 'c':
@@ -128,6 +153,7 @@ void ArduinoMenu::handleMainInput(char c) {
             showMainMenu();
             break;
         default:
+            setStatusMessage("Unknown option. Press [H] for help.");
             break;
     }
 }
@@ -136,11 +162,21 @@ void ArduinoMenu::updateLiveDisplay() {
     static unsigned long last = 0;
     if (millis() - last > 1000) {
         last = millis();
+        float d = _vane->direction();
 #ifdef ARDUINO
         Serial.print("\rDir: ");
-        Serial.print(_vane->direction(),1);
-        Serial.print("\xC2\xB0   \r");
+        Serial.print(d,1);
+        Serial.print("\xC2\xB0 (");
+        Serial.print(compassPoint(d));
+        Serial.print(")   \r");
+#else
+        cout << "\rDir: " << d << "\xC2\xB0 (" << compassPoint(d) << ")   \r" << std::flush;
 #endif
+    }
+    if (_io->hasInput()) {
+        _io->readInput();
+        _state = State::Main;
+        showMainMenu();
     }
 }
 
@@ -155,45 +191,70 @@ void ArduinoMenu::runCalibration() {
 
 void ArduinoMenu::showDiagnostics() {
 #ifdef ARDUINO
-    Serial.println("--- Diagnostics ---");
-    Serial.print("Calibration status: ");
-    switch (_vane->calibrationStatus()) {
-        case CalibrationManager::CalibrationStatus::Completed: Serial.println("OK"); break;
-        case CalibrationManager::CalibrationStatus::InProgress: Serial.println("In progress"); break;
-        case CalibrationManager::CalibrationStatus::AwaitingStart: Serial.println("Awaiting"); break;
-        default: Serial.println("Not started"); break;
+    size_t index = 0;
+    while (true) {
+        Serial.println("--- Diagnostics ---");
+        Serial.print("Calibration status: ");
+        switch (_vane->calibrationStatus()) {
+            case CalibrationManager::CalibrationStatus::Completed: Serial.println("OK"); break;
+            case CalibrationManager::CalibrationStatus::InProgress: Serial.println("In progress"); break;
+            case CalibrationManager::CalibrationStatus::AwaitingStart: Serial.println("Awaiting"); break;
+            default: Serial.println("Not started"); break;
+        }
+        Serial.print("Last calibration: ");
+        Serial.print((millis() - _lastCalibration)/60000UL);
+        Serial.println(" minutes ago");
+        if (_buffered) {
+            auto& hist = _buffered->history();
+            for (size_t i=0;i<5 && index+i<hist.size();++i)
+                Serial.println(hist[index+i].c_str());
+        }
+        Serial.println("[N]ext [P]rev [C]lear [T]est [B]ack");
+        while (!_io->hasInput()) _io->waitMs(10);
+        char c = _io->readInput();
+        if (c=='N'||c=='n') { if (_buffered && index+5<_buffered->history().size()) index+=5; }
+        else if (c=='P'||c=='p') { if (index>=5) index-=5; }
+        else if (c=='C'||c=='c') { if (_buffered && _io->yesNoPrompt("Clear logs? (Y/N)")) _buffered->clear(); index=0; }
+        else if (c=='T'||c=='t') { selfTest(); }
+        else break;
     }
-    Serial.print("Last calibration: ");
-    Serial.print((millis() - _lastCalibration)/60000UL);
-    Serial.println(" minutes ago");
-    if (_buffered) {
-        for (const auto& msg : _buffered->history())
-            Serial.println(msg.c_str());
-    }
-    Serial.println("Press any key to return");
-    while (!_io->hasInput())
-        _io->waitMs(10);
-    _io->flushInput();
 #endif
 }
 
 void ArduinoMenu::settingsMenu() {
 #ifdef ARDUINO
     Serial.println("--- Settings ---");
-    Serial.println("[R] Restore defaults");
-    Serial.println("[B] Back");
+    Serial.print("Threshold: "); Serial.println(_settings->spin.threshold);
+    Serial.print("Detents: "); Serial.println(_settings->spin.expectedPositions);
+    Serial.print("Smoothing: "); Serial.println(_settings->spin.bufferSize);
+    Serial.println("[1] Threshold  [2] Detents  [3] Smoothing");
+    Serial.println("[F] Factory reset  [B] Back");
     while (true) {
         while (!_io->hasInput()) _io->waitMs(10);
         char c = _io->readInput();
-        if (c == 'R' || c == 'r') {
-            if (_io->yesNoPrompt("Restore factory calibration? (Y/N)")) {
-                _vane->runCalibration();
-                _lastCalibration = millis();
+        if (c == '1') {
+            Serial.println("Enter new threshold:");
+            float v = readFloat();
+            if (_io->yesNoPrompt("Apply? (Y/N)")) _settings->spin.threshold = v;
+        } else if (c=='2') {
+            Serial.println("Enter detent count:");
+            int v = readInt();
+            if (_io->yesNoPrompt("Apply? (Y/N)")) _settings->spin.expectedPositions = v;
+        } else if (c=='3') {
+            Serial.println("Enter smoothing size:");
+            int v = readInt();
+            if (_io->yesNoPrompt("Apply? (Y/N)")) _settings->spin.bufferSize = v;
+        } else if (c=='F' || c=='f') {
+            if (_io->yesNoPrompt("Factory reset? (Y/N)")) {
+                if (_storage) _storage->clear();
+                *_settings = SettingsData();
             }
+        } else if (c=='B' || c=='b' || c=='\n' || c=='\r') {
             break;
         }
-        if (c == 'B' || c == 'b') break;
     }
+    if (_settingsStorage) _settingsStorage->save(*_settings);
+    _vane->setCalibrationConfig(_settings->spin);
 #endif
 }
 
@@ -206,4 +267,42 @@ void ArduinoMenu::showHelp() {
     Serial.println("S: Settings and maintenance");
     Serial.println("H: Show this help text");
 #endif
+}
+
+void ArduinoMenu::setStatusMessage(const char* msg, unsigned long ms) {
+    _statusMsg = msg;
+    _msgExpiry = millis() + ms;
+}
+
+float ArduinoMenu::readFloat() {
+#ifdef ARDUINO
+    while (!Serial.available()) _io->waitMs(10);
+    float v = Serial.parseFloat();
+    Serial.readStringUntil('\n');
+    return v;
+#else
+    float v; std::cin >> v; std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n'); return v;
+#endif
+}
+
+int ArduinoMenu::readInt() {
+#ifdef ARDUINO
+    while (!Serial.available()) _io->waitMs(10);
+    int v = Serial.parseInt();
+    Serial.readStringUntil('\n');
+    return v;
+#else
+    int v; std::cin >> v; std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n'); return v;
+#endif
+}
+
+void ArduinoMenu::selfTest() {
+    bool ok = true;
+    float d = _vane->direction();
+    if (d < 0 || d >= 360) ok = false;
+    if (ok) {
+        if (_diag) _diag->info("Self-test OK");
+    } else {
+        if (_diag) _diag->warn("Self-test failed");
+    }
 }

--- a/lib/Menu/ArduinoMenu.h
+++ b/lib/Menu/ArduinoMenu.h
@@ -3,10 +3,17 @@
 #include <IO/IIOHandler.h>
 #include <Diagnostics/IDiagnostics.h>
 #include <Diagnostics/BufferedDiagnostics.h>
+#include <Storage/ICalibrationStorage.h>
+#include <Settings/ISettingsStorage.h>
+#include <Settings/SettingsData.h>
+#include <string>
 
 class ArduinoMenu {
 public:
-    ArduinoMenu(WindVane* vane, IIOHandler* io, IDiagnostics* diag);
+    ArduinoMenu(WindVane* vane, IIOHandler* io, IDiagnostics* diag,
+                ICalibrationStorage* storage = nullptr,
+                ISettingsStorage* settingsStorage = nullptr,
+                SettingsData* settings = nullptr);
     void begin();
     void update();
 private:
@@ -16,6 +23,11 @@ private:
     IIOHandler* _io;
     IDiagnostics* _diag;
     BufferedDiagnostics* _buffered{nullptr};
+    ICalibrationStorage* _storage{nullptr};
+    ISettingsStorage* _settingsStorage{nullptr};
+    SettingsData* _settings{nullptr};
+    std::string _statusMsg;
+    unsigned long _msgExpiry{0};
     State _state;
     unsigned long _lastActivity;
     unsigned long _lastCalibration;
@@ -28,4 +40,8 @@ private:
     void showDiagnostics();
     void settingsMenu();
     void showHelp();
+    void selfTest();
+    void setStatusMessage(const char* msg, unsigned long ms = 3000);
+    float readFloat();
+    int readInt();
 };

--- a/lib/Menu/ArduinoMenu.h
+++ b/lib/Menu/ArduinoMenu.h
@@ -27,6 +27,7 @@ private:
     ISettingsStorage* _settingsStorage{nullptr};
     SettingsData* _settings{nullptr};
     std::string _statusMsg;
+    StatusLevel _statusLevel{StatusLevel::Normal};
     unsigned long _msgExpiry{0};
     State _state;
     unsigned long _lastActivity;
@@ -41,7 +42,10 @@ private:
     void settingsMenu();
     void showHelp();
     void selfTest();
-    void setStatusMessage(const char* msg, unsigned long ms = 3000);
+    enum class StatusLevel { Normal, Warning, Error };
+    void setStatusMessage(const char* msg, StatusLevel lvl = StatusLevel::Normal,
+                          unsigned long ms = 3000);
+    void clearScreen();
     float readFloat();
     int readInt();
 };

--- a/lib/WindVane/Calibration/CalibrationManager.h
+++ b/lib/WindVane/Calibration/CalibrationManager.h
@@ -31,6 +31,8 @@ public:
   // Gets the current calibration status
   CalibrationStatus getStatus() const;
 
+  ICalibrationStrategy* strategy() const { return calibrationStrategy.get(); }
+
 private:
   std::unique_ptr<ICalibrationStrategy> calibrationStrategy;
   CalibrationStatus status;

--- a/lib/WindVane/Calibration/Strategies/SpinningMethod.h
+++ b/lib/WindVane/Calibration/Strategies/SpinningMethod.h
@@ -33,6 +33,9 @@ public:
   // Map a raw ADC reading to a calibrated direction in degrees
   float mapReading(float reading) const override;
 
+  const SpinningConfig& config() const { return _config; }
+  void setConfig(const SpinningConfig& cfg) { _config = cfg; }
+
   static constexpr int CALIBRATION_VERSION = 1;
 
 private:

--- a/lib/WindVane/Diagnostics/BufferedDiagnostics.h
+++ b/lib/WindVane/Diagnostics/BufferedDiagnostics.h
@@ -27,6 +27,8 @@ public:
 
     const std::deque<std::string>& history() const { return _messages; }
 
+    void clear() { _messages.clear(); }
+
 private:
     size_t _max;
     std::deque<std::string> _messages;

--- a/lib/WindVane/Settings/EEPROMSettingsStorage.cpp
+++ b/lib/WindVane/Settings/EEPROMSettingsStorage.cpp
@@ -1,0 +1,29 @@
+#include "EEPROMSettingsStorage.h"
+
+EEPROMSettingsStorage::EEPROMSettingsStorage(size_t start)
+    : _start(start) {}
+
+void EEPROMSettingsStorage::save(const SettingsData& data) {
+#ifdef ARDUINO
+    EEPROM.begin(512);
+    size_t addr = _start;
+    EEPROM.put(addr, data.spin); addr += sizeof(SpinningConfig);
+    EEPROM.commit();
+    EEPROM.end();
+#else
+    (void)data;
+#endif
+}
+
+bool EEPROMSettingsStorage::load(SettingsData& data) {
+#ifdef ARDUINO
+    EEPROM.begin(512);
+    size_t addr = _start;
+    EEPROM.get(addr, data.spin); addr += sizeof(SpinningConfig);
+    EEPROM.end();
+    return true;
+#else
+    (void)data;
+    return false;
+#endif
+}

--- a/lib/WindVane/Settings/EEPROMSettingsStorage.h
+++ b/lib/WindVane/Settings/EEPROMSettingsStorage.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "ISettingsStorage.h"
+#ifdef ARDUINO
+#include <EEPROM.h>
+#endif
+
+class EEPROMSettingsStorage : public ISettingsStorage {
+public:
+    explicit EEPROMSettingsStorage(size_t startAddress = 256);
+    void save(const SettingsData& data) override;
+    bool load(SettingsData& data) override;
+private:
+    size_t _start;
+};

--- a/lib/WindVane/Settings/FileSettingsStorage.cpp
+++ b/lib/WindVane/Settings/FileSettingsStorage.cpp
@@ -1,0 +1,21 @@
+#include "FileSettingsStorage.h"
+#include <fstream>
+
+FileSettingsStorage::FileSettingsStorage(const std::string& path)
+    : _path(path) {}
+
+void FileSettingsStorage::save(const SettingsData& data) {
+    std::ofstream ofs(_path);
+    ofs << data.spin.threshold << " " << data.spin.bufferSize << " "
+        << data.spin.expectedPositions << " " << data.spin.sampleDelayMs << " "
+        << data.spin.stallTimeoutSec << "\n";
+}
+
+bool FileSettingsStorage::load(SettingsData& data) {
+    std::ifstream ifs(_path);
+    if (!ifs)
+        return false;
+    ifs >> data.spin.threshold >> data.spin.bufferSize >> data.spin.expectedPositions
+        >> data.spin.sampleDelayMs >> data.spin.stallTimeoutSec;
+    return static_cast<bool>(ifs);
+}

--- a/lib/WindVane/Settings/FileSettingsStorage.h
+++ b/lib/WindVane/Settings/FileSettingsStorage.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "ISettingsStorage.h"
+#include <string>
+
+class FileSettingsStorage : public ISettingsStorage {
+public:
+    explicit FileSettingsStorage(const std::string& path);
+    void save(const SettingsData& data) override;
+    bool load(SettingsData& data) override;
+private:
+    std::string _path;
+};

--- a/lib/WindVane/Settings/ISettingsStorage.h
+++ b/lib/WindVane/Settings/ISettingsStorage.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "SettingsData.h"
+
+class ISettingsStorage {
+public:
+    virtual ~ISettingsStorage() = default;
+    virtual void save(const SettingsData& data) = 0;
+    virtual bool load(SettingsData& data) = 0;
+};

--- a/lib/WindVane/Settings/SettingsData.h
+++ b/lib/WindVane/Settings/SettingsData.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "../Calibration/Strategies/SpinningMethod.h"
+
+struct SettingsData {
+    SpinningConfig spin;
+};

--- a/lib/WindVane/Storage/EEPROMCalibrationStorage.cpp
+++ b/lib/WindVane/Storage/EEPROMCalibrationStorage.cpp
@@ -54,3 +54,21 @@ bool EEPROMCalibrationStorage::load(std::vector<ClusterData>& clusters, int &ver
     return false;
 #endif
 }
+
+void EEPROMCalibrationStorage::clear() {
+#ifdef ARDUINO
+    size_t addr = _startAddress;
+    EEPROM.begin(512);
+    int version = 0;
+    EEPROM.put(addr, version); addr += sizeof(int);
+    uint32_t ts = 0;
+    EEPROM.put(addr, ts); addr += sizeof(uint32_t);
+    uint16_t count = 0;
+    EEPROM.put(addr, count); addr += sizeof(uint16_t);
+    EEPROM.commit();
+    EEPROM.end();
+    _lastTimestamp = 0;
+#else
+    /* no-op */
+#endif
+}

--- a/lib/WindVane/Storage/EEPROMCalibrationStorage.h
+++ b/lib/WindVane/Storage/EEPROMCalibrationStorage.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "ICalibrationStorage.h"
+#include <cstdint>
 #ifdef ARDUINO
 #include <EEPROM.h>
 #endif
@@ -10,6 +11,7 @@ public:
     void save(const std::vector<ClusterData>& clusters, int version) override;
     bool load(std::vector<ClusterData>& clusters, int &version) override;
     uint32_t lastTimestamp() const { return _lastTimestamp; }
+    void clear() override;
 
 private:
     size_t _startAddress;

--- a/lib/WindVane/Storage/FileCalibrationStorage.cpp
+++ b/lib/WindVane/Storage/FileCalibrationStorage.cpp
@@ -35,3 +35,9 @@ bool FileCalibrationStorage::load(std::vector<ClusterData>& clusters, int &versi
     }
     return true;
 }
+
+void FileCalibrationStorage::clear() {
+    std::error_code ec;
+    std::filesystem::remove(_path, ec);
+    _lastTimestamp = 0;
+}

--- a/lib/WindVane/Storage/FileCalibrationStorage.h
+++ b/lib/WindVane/Storage/FileCalibrationStorage.h
@@ -2,6 +2,7 @@
 
 #include "ICalibrationStorage.h"
 #include <string>
+#include <cstdint>
 
 class FileCalibrationStorage : public ICalibrationStorage {
 public:
@@ -9,6 +10,7 @@ public:
     void save(const std::vector<ClusterData>& clusters, int version) override;
     bool load(std::vector<ClusterData>& clusters, int &version) override;
     uint32_t lastTimestamp() const override { return _lastTimestamp; }
+    void clear() override;
 
 private:
     std::string _path;

--- a/lib/WindVane/Storage/ICalibrationStorage.h
+++ b/lib/WindVane/Storage/ICalibrationStorage.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+#include <cstdint>
 #include "../Calibration/ClusterData.h"
 
 class ICalibrationStorage {
@@ -8,4 +9,5 @@ public:
     virtual void save(const std::vector<ClusterData>& clusters, int version) = 0;
     virtual bool load(std::vector<ClusterData>& clusters, int &version) = 0;
     virtual uint32_t lastTimestamp() const { return 0; }
+    virtual void clear() = 0;
 };

--- a/lib/WindVane/WindVane.cpp
+++ b/lib/WindVane/WindVane.cpp
@@ -3,6 +3,7 @@
 #include "Storage/ICalibrationStorage.h"
 #include "IO/IIOHandler.h"
 #include "Diagnostics/IDiagnostics.h"
+#include "Calibration/Strategies/SpinningMethod.h"
 
 WindVane::WindVane(IADC *adc, WindVaneType type,
                    CalibrationMethod method,
@@ -36,4 +37,28 @@ CalibrationManager::CalibrationStatus WindVane::calibrationStatus() const {
 
 uint32_t WindVane::lastCalibrationTimestamp() const {
     return _storage ? _storage->lastTimestamp() : 0;
+}
+
+void WindVane::clearCalibration() {
+    if (_storage)
+        _storage->clear();
+}
+
+void WindVane::setCalibrationConfig(const SpinningConfig &cfg) {
+    if (_calibrationManager) {
+        auto strat = dynamic_cast<SpinningMethod*>(
+            _calibrationManager->strategy());
+        if (strat)
+            strat->setConfig(cfg);
+    }
+}
+
+SpinningConfig WindVane::getCalibrationConfig() const {
+    if (_calibrationManager) {
+        auto strat = dynamic_cast<SpinningMethod*>(
+            _calibrationManager->strategy());
+        if (strat)
+            return strat->config();
+    }
+    return {};
 }

--- a/lib/WindVane/WindVane.h
+++ b/lib/WindVane/WindVane.h
@@ -70,6 +70,13 @@ public:
   /// Returns the current calibration status
   CalibrationManager::CalibrationStatus calibrationStatus() const;
 
+  void clearCalibration();
+
+  void setCalibrationConfig(const SpinningConfig &cfg);
+  SpinningConfig getCalibrationConfig() const;
+
+  ICalibrationStorage* storage() const { return _storage; }
+
 private:
   /**
    * @brief Gets the raw wind direction from the ADC interface.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,8 @@
 #include <Storage/EEPROMCalibrationStorage.h>
 #include <IO/SerialIOHandler.h>
 #include <Diagnostics/BufferedDiagnostics.h>
+#include <Settings/FileSettingsStorage.h>
+#include <Settings/SettingsData.h>
 #include <Menu/ArduinoMenu.h>
 #include "Config.h"
 
@@ -13,6 +15,8 @@ std::unique_ptr<ESP32ADC> adc;
 std::unique_ptr<EEPROMCalibrationStorage> storage;
 std::unique_ptr<SerialIOHandler> io;
 std::unique_ptr<BufferedDiagnostics> diag;
+std::unique_ptr<FileSettingsStorage> settingsStore;
+SettingsData settings;
 std::unique_ptr<WindVane> windVane;
 std::unique_ptr<ArduinoMenu> menu;
 
@@ -22,10 +26,15 @@ void setup() {
   storage = std::make_unique<EEPROMCalibrationStorage>(0);
   io = std::make_unique<SerialIOHandler>();
   diag = std::make_unique<BufferedDiagnostics>();
+  settingsStore = std::make_unique<FileSettingsStorage>("settings.cfg");
+  settingsStore->load(settings);
   windVane = std::make_unique<WindVane>(adc.get(), WindVaneType::REED_SWITCH,
                                         CalibrationMethod::SPINNING,
-                                        storage.get(), io.get(), diag.get());
-  menu = std::make_unique<ArduinoMenu>(windVane.get(), io.get(), diag.get());
+                                        storage.get(), io.get(), diag.get(),
+                                        settings.spin);
+  menu = std::make_unique<ArduinoMenu>(windVane.get(), io.get(), diag.get(),
+                                       storage.get(), settingsStore.get(),
+                                       &settings);
   menu->begin();
 }
 


### PR DESCRIPTION
## Summary
- enhance menu with status messages and help on unknown input
- add compass rose display and exit-live-display on any key
- implement persistent settings storage and factory reset
- support scrolling diagnostics with self-test and log clearing
- expose calibration and settings controls in `WindVane`

## Testing
- `platformio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_68653b23f1d4832e909bb1e083f6c960