### PR TITLE
Fix cast to spinning configurable

### DIFF
--- a/lib/Menu/ArduinoMenu.h
+++ b/lib/Menu/ArduinoMenu.h
@@ -36,6 +36,7 @@ private:
     ISettingsStorage* _settingsStorage{nullptr};
     SettingsData* _settings{nullptr};
     std::string _statusMsg;
+    enum class StatusLevel { Normal, Warning, Error };
     StatusLevel _statusLevel{StatusLevel::Normal};
     unsigned long _msgExpiry{0};
     State _state;
@@ -58,7 +59,6 @@ private:
     void updateLiveDisplay();
     void runCalibration();
     void showHelp();
-    enum class StatusLevel { Normal, Warning, Error };
     void setStatusMessage(const char* msg, StatusLevel lvl = StatusLevel::Normal,
                           unsigned long ms = 3000);
     void clearScreen();

--- a/lib/WindVane/WindVane.cpp
+++ b/lib/WindVane/WindVane.cpp
@@ -44,7 +44,7 @@ void WindVane::clearCalibration() {
 
 void WindVane::setCalibrationConfig(const SpinningConfig &cfg) {
     if (_calibrationManager) {
-        auto strat = static_cast<ISpinningConfigurable*>(
+        auto strat = dynamic_cast<ISpinningConfigurable*>(
             _calibrationManager->strategy());
         if (strat)
             strat->setConfig(cfg);
@@ -53,7 +53,7 @@ void WindVane::setCalibrationConfig(const SpinningConfig &cfg) {
 
 SpinningConfig WindVane::getCalibrationConfig() const {
     if (_calibrationManager) {
-        auto strat = static_cast<ISpinningConfigurable*>(
+        auto strat = dynamic_cast<ISpinningConfigurable*>(
             _calibrationManager->strategy());
         if (strat)
             return strat->config();


### PR DESCRIPTION
## Summary
- fix `WindVane` calibration config casts using `dynamic_cast`
- move `StatusLevel` enum ahead of its use in `ArduinoMenu`

## Testing
- `platformio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_6865e5e6a5b8832eaa131402a163d73b