### PR TITLE
Refactor menu presentation logic

### DIFF
--- a/lib/WindVaneMenu/WindVaneMenu.h
+++ b/lib/WindVaneMenu/WindVaneMenu.h
@@ -8,6 +8,9 @@
 #include <Settings/SettingsData.h>
 #include <Storage/ICalibrationStorage.h>
 #include <WindVane.h>
+#include "WindVaneMenuLogic.h"
+#include "WindVaneMenuPresenter.h"
+#include "WindVaneMenuTypes.h"
 
 #include <string>
 
@@ -40,6 +43,8 @@ class WindVaneMenu {
   SettingsData* _settings;
   INumericReader* _numeric;  // <-- DECLARE _numeric
 
+  WindVaneMenuLogic _logic;
+  WindVaneMenuPresenter _presenter;
   enum class State {
     Main,
     LiveDisplay,
@@ -52,20 +57,14 @@ class WindVaneMenu {
   unsigned long _lastActivity;
   unsigned long _lastCalibration;
 
-  enum class StatusLevel { Normal, Warning, Error };
   std::string _statusMsg;
-  StatusLevel _statusLevel{StatusLevel::Normal};
+  MenuStatusLevel _statusLevel{MenuStatusLevel::Normal};
   unsigned long _msgExpiry{0};
 
   void showStatusLine();
   void showMainMenu();
   void handleMainInput(char c);
   void updateLiveDisplay();
-  const char* statusText(CalibrationManager::CalibrationStatus st) const;
-  void renderStatusLineArduino(float dir, const char* statusStr,
-                               unsigned long ago);
-  void renderStatusLineHost(float dir, const char* statusStr,
-                            unsigned long ago);
   void clearExpiredMessage();
   void runCalibration();
   void handleDisplaySelection();
@@ -76,6 +75,6 @@ class WindVaneMenu {
   void handleUnknownSelection();
   void showHelp();
   void clearScreen();
-  void setStatusMessage(const char* msg, StatusLevel lvl = StatusLevel::Normal,
+  void setStatusMessage(const char* msg, MenuStatusLevel lvl = MenuStatusLevel::Normal,
                         unsigned long ms = 3000);
 };

--- a/lib/WindVaneMenu/WindVaneMenuLogic.cpp
+++ b/lib/WindVaneMenu/WindVaneMenuLogic.cpp
@@ -1,0 +1,36 @@
+#include "WindVaneMenuLogic.h"
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#else
+#include <chrono>
+static unsigned long millis() {
+    using namespace std::chrono;
+    static auto start = steady_clock::now();
+    return duration_cast<milliseconds>(steady_clock::now() - start).count();
+}
+#endif
+
+WindVaneStatus WindVaneMenuLogic::queryStatus(WindVane* vane, unsigned long lastCalibration) const {
+    WindVaneStatus status;
+    if (vane) {
+        status.direction = vane->direction();
+        status.calibrationStatus = vane->calibrationStatus();
+    }
+    status.minutesSinceCalibration = (millis() - lastCalibration) / 60000UL;
+    return status;
+}
+
+const char* WindVaneMenuLogic::statusText(CalibrationManager::CalibrationStatus st) const {
+    switch (st) {
+        case CalibrationManager::CalibrationStatus::NotStarted:
+            return "Uncal";
+        case CalibrationManager::CalibrationStatus::AwaitingStart:
+            return "Awaiting";
+        case CalibrationManager::CalibrationStatus::InProgress:
+            return "Calibrating";
+        case CalibrationManager::CalibrationStatus::Completed:
+            return "OK";
+    }
+    return "Unknown";
+}

--- a/lib/WindVaneMenu/WindVaneMenuLogic.h
+++ b/lib/WindVaneMenu/WindVaneMenuLogic.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "WindVaneStatus.h"
+#include <WindVane.h>
+
+class WindVaneMenuLogic {
+ public:
+  WindVaneStatus queryStatus(WindVane* vane, unsigned long lastCalibration) const;
+  const char* statusText(CalibrationManager::CalibrationStatus st) const;
+};

--- a/lib/WindVaneMenu/WindVaneMenuPresenter.cpp
+++ b/lib/WindVaneMenu/WindVaneMenuPresenter.cpp
@@ -1,0 +1,51 @@
+static const char* compassPoint(float deg) {
+    static const char* pts[] = {"N", "NE", "E", "SE", "S", "SW", "W", "NW"};
+    int idx = static_cast<int>((deg + 22.5f) / 45.0f) & 7;
+    return pts[idx];
+}
+#include "WindVaneMenuPresenter.h"
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#else
+#include <cstdio>
+#endif
+
+void WindVaneMenuPresenter::renderStatusLineArduino(const WindVaneStatus& st, const char* statusStr,
+                               const std::string& msg, MenuStatusLevel level) const {
+    char line[80];
+    snprintf(line, sizeof(line),
+             "\rDir:%6.1f\xC2\xB0 %-2s Status:%-10s Cal:%4lum", st.direction,
+             compassPoint(st.direction), statusStr, st.minutesSinceCalibration);
+    _out->write(line);
+    if (!msg.empty()) {
+        if (level != MenuStatusLevel::Normal) _out->write(" !! ");
+        _out->write(msg.c_str());
+    }
+    _out->write("    \r");
+}
+
+void WindVaneMenuPresenter::renderStatusLineHost(const WindVaneStatus& st, const char* statusStr,
+                             const std::string& msg, MenuStatusLevel level) const {
+    char line[80];
+    snprintf(line, sizeof(line),
+             "\rDir:%6.1f\xC2\xB0 %-2s Status:%-10s Cal:%4lum", st.direction,
+             compassPoint(st.direction), statusStr, st.minutesSinceCalibration);
+    _out->write(line);
+    if (!msg.empty()) {
+        const char* color = "";
+        const char* reset = "";
+        if (level == MenuStatusLevel::Warning) {
+            color = "\033[33m";
+            reset = "\033[0m";
+        } else if (level == MenuStatusLevel::Error) {
+            color = "\033[31m";
+            reset = "\033[0m";
+        }
+        _out->write(" ");
+        _out->write(color);
+        _out->write(msg.c_str());
+        _out->write(reset);
+    }
+    _out->write("    \r");
+}

--- a/lib/WindVaneMenu/WindVaneMenuPresenter.h
+++ b/lib/WindVaneMenu/WindVaneMenuPresenter.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "WindVaneStatus.h"
+#include "WindVaneMenuTypes.h"
+#include <IO/IOutput.h>
+#include <string>
+
+class WindVaneMenuPresenter {
+ public:
+  explicit WindVaneMenuPresenter(IOutput* out) : _out(out) {}
+  void renderStatusLineArduino(const WindVaneStatus& st, const char* statusStr,
+                               const std::string& msg, MenuStatusLevel level) const;
+  void renderStatusLineHost(const WindVaneStatus& st, const char* statusStr,
+                            const std::string& msg, MenuStatusLevel level) const;
+
+ private:
+  IOutput* _out;
+};

--- a/lib/WindVaneMenu/WindVaneMenuTypes.h
+++ b/lib/WindVaneMenu/WindVaneMenuTypes.h
@@ -1,0 +1,3 @@
+#pragma once
+
+enum class MenuStatusLevel { Normal, Warning, Error };

--- a/lib/WindVaneMenu/WindVaneStatus.h
+++ b/lib/WindVaneMenu/WindVaneStatus.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <WindVane.h>
+
+struct WindVaneStatus {
+    float direction{0.0f};
+    CalibrationManager::CalibrationStatus calibrationStatus{
+        CalibrationManager::CalibrationStatus::NotStarted};
+    unsigned long minutesSinceCalibration{0};
+};


### PR DESCRIPTION
## Summary
- introduce `WindVaneStatus` data model
- add `WindVaneMenuLogic` service layer
- add `WindVaneMenuPresenter` for rendering
- use new logic/presenter in `WindVaneMenu`

## Testing
- `pio test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f43c2d78832e866f44b52c12a74a