### PR TITLE
Unify TimeMs across platforms

### DIFF
--- a/lib/Platform/Platform.h
+++ b/lib/Platform/Platform.h
@@ -9,7 +9,7 @@
 
 class ArduinoPlatform : public IPlatform {
 public:
-    platform::TimeMs millis() const override { return ::millis(); }
+    platform::TimeMs millis() const override { return platform::TimeMs{::millis()}; }
     void renderStatusLine(WindVaneMenuPresenter& presenter,
                           const WindVaneStatus& st,
                           const char* statusStr,
@@ -34,7 +34,7 @@ public:
     platform::TimeMs millis() const override {
         using namespace std::chrono;
         static auto start = steady_clock::now();
-        return duration_cast<milliseconds>(steady_clock::now() - start);
+        return platform::TimeMs{static_cast<platform::TimeMs::rep>(duration_cast<milliseconds>(steady_clock::now() - start).count())};
     }
     void renderStatusLine(WindVaneMenuPresenter& presenter,
                           const WindVaneStatus& st,

--- a/lib/Platform/TimeUtils.h
+++ b/lib/Platform/TimeUtils.h
@@ -1,14 +1,58 @@
 #pragma once
 #include <chrono>
+#include <cstdint>
 
 namespace platform {
+
+struct TimeMs {
+    using rep = uint32_t;
+    rep value;
+
+    constexpr TimeMs() : value(0) {}
+    explicit constexpr TimeMs(rep v) : value(v) {}
+    explicit constexpr TimeMs(std::chrono::milliseconds d)
+        : value(static_cast<rep>(d.count())) {}
+
+    constexpr rep count() const { return value; }
+
+    constexpr TimeMs operator+(TimeMs other) const {
+        return TimeMs{static_cast<rep>(value + other.value)};
+    }
+    constexpr TimeMs operator-(TimeMs other) const {
+        return TimeMs{static_cast<rep>(value - other.value)};
+    }
+    TimeMs& operator+=(TimeMs other) {
+        value = static_cast<rep>(value + other.value);
+        return *this;
+    }
+    TimeMs& operator-=(TimeMs other) {
+        value = static_cast<rep>(value - other.value);
+        return *this;
+    }
+
+    friend constexpr bool operator==(TimeMs a, TimeMs b) { return a.value == b.value; }
+    friend constexpr bool operator!=(TimeMs a, TimeMs b) { return a.value != b.value; }
+    friend constexpr bool operator<(TimeMs a, TimeMs b) { return a.value < b.value; }
+    friend constexpr bool operator>(TimeMs a, TimeMs b) { return a.value > b.value; }
+    friend constexpr bool operator<=(TimeMs a, TimeMs b) { return a.value <= b.value; }
+    friend constexpr bool operator>=(TimeMs a, TimeMs b) { return a.value >= b.value; }
+};
+
+inline TimeMs add(TimeMs a, TimeMs b) { return a + b; }
+inline TimeMs elapsed(TimeMs start, TimeMs end) { return end - start; }
+
 #ifdef ARDUINO
-using TimeMs = unsigned long;
-inline TimeMs toEmbedded(std::chrono::milliseconds d) { return static_cast<TimeMs>(d.count()); }
-inline std::chrono::milliseconds toChrono(TimeMs ms) { return std::chrono::milliseconds(ms); }
+inline TimeMs now() { return TimeMs{::millis()}; }
 #else
-using TimeMs = std::chrono::milliseconds;
-inline TimeMs toEmbedded(std::chrono::milliseconds d) { return d; }
-inline std::chrono::milliseconds toChrono(TimeMs d) { return d; }
-#endif
+inline TimeMs now() {
+    using namespace std::chrono;
+    static auto start = steady_clock::now();
+    return TimeMs{static_cast<TimeMs::rep>(duration_cast<milliseconds>(steady_clock::now() - start).count())};
 }
+#endif
+
+inline uint32_t toEmbedded(TimeMs t) { return t.count(); }
+inline std::chrono::milliseconds toChrono(TimeMs t) { return std::chrono::milliseconds(t.count()); }
+inline TimeMs fromChrono(std::chrono::milliseconds d) { return TimeMs{static_cast<TimeMs::rep>(d.count())}; }
+
+} // namespace platform

--- a/test/test_time/TimeMs.cpp
+++ b/test/test_time/TimeMs.cpp
@@ -1,0 +1,21 @@
+#include <Platform/TimeUtils.h>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(TimeMsTest, BasicArithmetic) {
+    platform::TimeMs a{100};
+    platform::TimeMs b{50};
+    platform::TimeMs c = a + b;
+    EXPECT_EQ(c.count(), 150u);
+    EXPECT_EQ((c - a).count(), 50u);
+}
+
+TEST(TimeMsTest, RolloverSubtraction) {
+    using rep = platform::TimeMs::rep;
+    rep max = std::numeric_limits<rep>::max();
+    platform::TimeMs near_wrap{max - 10};
+    platform::TimeMs later{5};
+    platform::TimeMs diff = later - near_wrap;
+    EXPECT_EQ(diff.count(), 16u); // 5 - (max-10) wraps to 16
+}
+


### PR DESCRIPTION
## Summary
- unify time handling in `TimeUtils.h` with `TimeMs` struct
- adjust platform implementations to return the new type
- add tests verifying `TimeMs` arithmetic and rollover behaviour

## Testing
- `platformio --version`
- `pip install platformio==6.1.6`
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_686633478840832ebce4cf9cb63608f1